### PR TITLE
Update README with Decimal package related info wrt scope for further improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Total: 74.68
 ```
 
 ### Scope for further improvements
+* Replacing Float related usage with [Decimal](https://github.com/ericmj/decimal)
 * Get a list of items exempt from basic sales tax based on user input
 * Incorporate more taxes related to a product like GST etc.,
 


### PR DESCRIPTION
When dealing with Money, like how we have `BigDecimal` in Ruby when dealing with money(one can read more on why [here](https://blog.bigbinary.com/2013/01/14/handling-money-in-ruby.html)), recently learnt that one could potentially use the `Decimal` package in Elixir for similar purposes.